### PR TITLE
Added a descriptive alt for images

### DIFF
--- a/src/visualization/extensions-introduction.md
+++ b/src/visualization/extensions-introduction.md
@@ -4,7 +4,7 @@ Lichtblick’s extensibility allows you to tailor the platform to your team’s 
 
 Once your extension is built and installed, you can manage it through the app settings, where all available and installed extensions are listed.
 
-![App Settings Extensions](/images/app-settings.png)
+![App settings](/images/app-settings.png)
 
 ---
 

--- a/src/visualization/introduction.md
+++ b/src/visualization/introduction.md
@@ -11,14 +11,14 @@ To begin visualizing your data, connect to a data source and open a panel.
 - Click "Open data source" in the left-hand menu.
 - Choose from available options: live data or local file.
 
-![alt text](/images/open-file.png)
+![Open file](/images/open-file.png)
 
 #### Opening a Panel:
 
 - Click "Add panel" in the dashboard or left-hand menu.
 - Select the desired panel type (e.g., 3D, Raw Message, Image).
 
-![alt text](/images/add-panel.png)
+![Add panel](/images/add-panel.png)
 
 ## Desktop-only features
 
@@ -35,7 +35,7 @@ Extensions
 
 Lichtblick's interface is designed for intuitive navigation:
 
-![alt text](/images/instructions-workspace.png)
+![Workspace instructions](/images/instructions-workspace.png)
 
 **App Menu**: Connect to a data source, toggle sidebars, or access resources.<br>
 **Users Menu**: Go to app settings, extensions catalog, experimental features, licenses, and version. <br>

--- a/src/visualization/layouts.md
+++ b/src/visualization/layouts.md
@@ -12,7 +12,7 @@ Layouts are highly versatile and can be adapted to various engineering and devel
 
 The **Layouts** menu provides all the tools needed to create, modify, and share layouts, ensuring a streamlined workflow.
 
-![alt text](/images/layouts-tab.png)
+![Layouts tab](/images/layouts-tab.png)
 
 ## Layouts Menu Overview
 
@@ -23,7 +23,7 @@ To create a new custom workspace:
 1. Navigate to the **Layouts** menu.
 2. Select **Create new layout**.
 
-![alt text](/images/new-layout.png)
+![Creating a new layout](/images/new-layout.png)
 
 #### Customization Options:
 
@@ -41,7 +41,7 @@ When switching layouts after making changes to your current workspace, you will 
 - **Save changes**: Save your modifications to the layout.
 - **Revert**: Discard changes and restore the last saved version.
 
-![alt text](/images/layout-options.png)
+![Layout options](/images/layout-options.png)
 
 ### Web Version Considerations
 

--- a/src/visualization/playback.md
+++ b/src/visualization/playback.md
@@ -2,7 +2,7 @@
 
 Lichtblick enables seamless navigation through both local and remote datasets using its playback controls.
 
-![alt text](/images/navigate-timestamp.png)
+![Playback](/images/navigate-timestamp.png)
 
 ## Message Sequencing
 

--- a/src/visualization/variables.md
+++ b/src/visualization/variables.md
@@ -4,7 +4,7 @@ Variables in Lichtblick allow users to define global values that can be reused a
 
 To manage variables, access the **Variables** tab in the sidebar, where you can view, add, and modify them.
 
-![variables](/images/show-sidebar.png)
+![Variables in sidebar](/images/show-sidebar.png)
 
 ---
 
@@ -16,7 +16,7 @@ Variables are referenced using the `$` prefix. For example, a variable named `my
 
 Panels that support message path syntax—such as **Raw Messages**, **Indicator**, **Plot**, and **State Transitions**—can leverage variables to dynamically filter or slice data. This enables flexible and interactive data visualization.
 
-![variables](/images/variables-in-message-path.png)
+![Variables in message path](/images/variables-in-message-path.png)
 
 #### Example Workflow:
 


### PR DESCRIPTION
Some images are not being displayed in `https://lichtblick-suite.github.io` but are being displayed in the `mdbook serve` dev environment. The suspicion is that there are repeated alt texts when declaring the images.

Topics:
5.1
5.2
5.4
5.5.1
5.6
5.7.1