### PR TITLE
docs: add frontmatter and Algolia search keywords to all pages

### DIFF
--- a/docs/browser-support.md
+++ b/docs/browser-support.md
@@ -2,6 +2,7 @@
 sidebar_position: 7
 title: Browser Support
 description: "Supported browsers and minimum versions for running Lichtblick."
+keywords: [browser support, chrome, firefox, compatibility, web app, minimum version]
 ---
 
 # Browser Support

--- a/docs/browser-support.md
+++ b/docs/browser-support.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 7
 title: Browser Support
+description: "Supported browsers and minimum versions for running Lichtblick."
 ---
 
 # Browser Support

--- a/docs/connecting-to-data/frameworks/introduction.md
+++ b/docs/connecting-to-data/frameworks/introduction.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 1
+title: "Frameworks"
+description: "Overview of data frameworks supported by Lichtblick, including ROS, MCAP, PX4, and Velodyne."
+---
+
 # Frameworks
 
 This section of the documentation provides a guide on how to connect Lichtblick to various data sources and understand the supported data formats and schema encodings. Whether you are working with live sensor data or recorded files, Lichtblick offers flexible options to integrate and visualize your information.

--- a/docs/connecting-to-data/frameworks/introduction.md
+++ b/docs/connecting-to-data/frameworks/introduction.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: "Frameworks"
 description: "Overview of data frameworks supported by Lichtblick, including ROS, MCAP, PX4, and Velodyne."
+keywords: [frameworks, ros, mcap, px4, velodyne, data formats, data sources]
 ---
 
 # Frameworks

--- a/docs/connecting-to-data/frameworks/mcap.md
+++ b/docs/connecting-to-data/frameworks/mcap.md
@@ -2,6 +2,7 @@
 sidebar_position: 2
 title: "MCAP"
 description: "Load local and remote MCAP files or connect to MCAP-based live data sources in Lichtblick."
+keywords: [mcap, file format, recording, playback, ros2, local data, remote data]
 ---
 
 # MCAP

--- a/docs/connecting-to-data/frameworks/mcap.md
+++ b/docs/connecting-to-data/frameworks/mcap.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 2
+title: "MCAP"
+description: "Load local and remote MCAP files or connect to MCAP-based live data sources in Lichtblick."
+---
+
 # MCAP
 
 Load local and remote [MCAP files](https://mcap.dev).

--- a/docs/connecting-to-data/frameworks/px-4.md
+++ b/docs/connecting-to-data/frameworks/px-4.md
@@ -2,6 +2,7 @@
 sidebar_position: 5
 title: "PX4 ULog"
 description: "Load PX4 ULog (.ulg) files for flight log visualization in Lichtblick."
+keywords: [px4, ulog, ulg, flight log, drone, uav, autopilot]
 ---
 
 # PX 4

--- a/docs/connecting-to-data/frameworks/px-4.md
+++ b/docs/connecting-to-data/frameworks/px-4.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 5
+title: "PX4 ULog"
+description: "Load PX4 ULog (.ulg) files for flight log visualization in Lichtblick."
+---
+
 # PX 4
 
 Load local PX 4 ULog (`ulg`) files for visualization.

--- a/docs/connecting-to-data/frameworks/ros1.md
+++ b/docs/connecting-to-data/frameworks/ros1.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 3
+title: "ROS 1"
+description: "Load ROS 1 bag files or connect to a live ROS 1 stack using Rosbridge or Foxglove Bridge."
+---
+
 # ROS 1
 
 Load local and remote ROS 1 (`.bag`) files, or connect directly to a live ROS 1 stack.

--- a/docs/connecting-to-data/frameworks/ros1.md
+++ b/docs/connecting-to-data/frameworks/ros1.md
@@ -2,6 +2,7 @@
 sidebar_position: 3
 title: "ROS 1"
 description: "Load ROS 1 bag files or connect to a live ROS 1 stack using Rosbridge or Foxglove Bridge."
+keywords: [ros1, ros, bag file, rosbridge, foxglove bridge, live connection, topics]
 ---
 
 # ROS 1

--- a/docs/connecting-to-data/frameworks/ros2.md
+++ b/docs/connecting-to-data/frameworks/ros2.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 4
+title: "ROS 2"
+description: "Load ROS 2 MCAP files or connect to a live ROS 2 stack using Rosbridge or Foxglove Bridge."
+---
+
 # ROS 2
 
 Load local and remote [MCAP](./mcap.md) files containing ROS 2 data, or connect directly to a live ROS 2 stack.

--- a/docs/connecting-to-data/frameworks/ros2.md
+++ b/docs/connecting-to-data/frameworks/ros2.md
@@ -2,6 +2,7 @@
 sidebar_position: 4
 title: "ROS 2"
 description: "Load ROS 2 MCAP files or connect to a live ROS 2 stack using Rosbridge or Foxglove Bridge."
+keywords: [ros2, ros 2, mcap, dds, rosbridge, foxglove bridge, live connection, topics]
 ---
 
 # ROS 2

--- a/docs/connecting-to-data/frameworks/rosbridge.md
+++ b/docs/connecting-to-data/frameworks/rosbridge.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 6
+title: "Rosbridge"
+description: "Connect Lichtblick to ROS 1 or ROS 2 via a Rosbridge WebSocket connection."
+---
+
 # Rosbridge
 
 <div class="warning">

--- a/docs/connecting-to-data/frameworks/rosbridge.md
+++ b/docs/connecting-to-data/frameworks/rosbridge.md
@@ -2,6 +2,7 @@
 sidebar_position: 6
 title: "Rosbridge"
 description: "Connect Lichtblick to ROS 1 or ROS 2 via a Rosbridge WebSocket connection."
+keywords: [rosbridge, websocket, ros1, ros2, live connection, foxglove bridge]
 ---
 
 # Rosbridge

--- a/docs/connecting-to-data/frameworks/schema-encodings.md
+++ b/docs/connecting-to-data/frameworks/schema-encodings.md
@@ -2,6 +2,7 @@
 sidebar_position: 7
 title: "Schema Encodings"
 description: "Supported message and schema encodings for MCAP and WebSocket data sources in Lichtblick."
+keywords: [schema encodings, protobuf, flatbuffers, json, ros, mcap, websocket, message format]
 ---
 
 # Schema encodings

--- a/docs/connecting-to-data/frameworks/schema-encodings.md
+++ b/docs/connecting-to-data/frameworks/schema-encodings.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 7
+title: "Schema Encodings"
+description: "Supported message and schema encodings for MCAP and WebSocket data sources in Lichtblick."
+---
+
 # Schema encodings
 
 Both MCAP-based and websockets sources support several message and schema encodings.

--- a/docs/connecting-to-data/frameworks/velodyne.md
+++ b/docs/connecting-to-data/frameworks/velodyne.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 8
+title: "Velodyne Lidar"
+description: "Connect to a Velodyne Lidar sensor over UDP to stream live point cloud data into Lichtblick."
+---
+
 # Velodyne
 
 <div class="warning">

--- a/docs/connecting-to-data/frameworks/velodyne.md
+++ b/docs/connecting-to-data/frameworks/velodyne.md
@@ -2,6 +2,7 @@
 sidebar_position: 8
 title: "Velodyne Lidar"
 description: "Connect to a Velodyne Lidar sensor over UDP to stream live point cloud data into Lichtblick."
+keywords: [velodyne, lidar, point cloud, udp, sensor, live data, desktop]
 ---
 
 # Velodyne

--- a/docs/connecting-to-data/introduction.md
+++ b/docs/connecting-to-data/introduction.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 1
+title: "Connecting to Data"
+description: "Overview of data source options in Lichtblick, including local files and live connections."
+---
+
 # Connecting to Data
 
 To begin visualizing data, navigate to the Lichtblick dashboard and select a data source option.

--- a/docs/connecting-to-data/introduction.md
+++ b/docs/connecting-to-data/introduction.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: "Connecting to Data"
 description: "Overview of data source options in Lichtblick, including local files and live connections."
+keywords: [data source, connection, local files, live data, ros, mcap, websocket]
 ---
 
 # Connecting to Data

--- a/docs/connecting-to-data/live-data.md
+++ b/docs/connecting-to-data/live-data.md
@@ -2,6 +2,7 @@
 sidebar_position: 3
 title: "Live Data"
 description: "Connect to live data sources including Foxglove WebSocket, Rosbridge, and Velodyne Lidar."
+keywords: [live data, websocket, rosbridge, velodyne, real-time, streaming, foxglove bridge]
 ---
 
 # Live Data

--- a/docs/connecting-to-data/live-data.md
+++ b/docs/connecting-to-data/live-data.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 3
+title: "Live Data"
+description: "Connect to live data sources including Foxglove WebSocket, Rosbridge, and Velodyne Lidar."
+---
+
 # Live Data
 
 Connect to live data sources using Lichtblick's WebSocket, Rosbridge, and Velodyne Lidar integrations for real-time streaming. You can also load remote data files via URL for easy access and processing.

--- a/docs/connecting-to-data/local-data.md
+++ b/docs/connecting-to-data/local-data.md
@@ -1,5 +1,7 @@
 ---
-position: 1
+sidebar_position: 2
+title: "Local Data"
+description: "Load local ROS 1 bag, ROS 2 MCAP, and PX4 ULog files for visualization in Lichtblick."
 ---
 
 # Local Data

--- a/docs/connecting-to-data/local-data.md
+++ b/docs/connecting-to-data/local-data.md
@@ -2,6 +2,7 @@
 sidebar_position: 2
 title: "Local Data"
 description: "Load local ROS 1 bag, ROS 2 MCAP, and PX4 ULog files for visualization in Lichtblick."
+keywords: [local data, bag file, mcap, ulog, ros1, ros2, px4, file loading]
 ---
 
 # Local Data

--- a/docs/connecting-to-data/multiple-files.md
+++ b/docs/connecting-to-data/multiple-files.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 4
+title: "Multiple Files"
+description: "Open and visualize multiple MCAP files simultaneously in a single Lichtblick session."
+---
+
 # Multiple files
 
 <div class="warning">

--- a/docs/connecting-to-data/multiple-files.md
+++ b/docs/connecting-to-data/multiple-files.md
@@ -2,6 +2,7 @@
 sidebar_position: 4
 title: "Multiple Files"
 description: "Open and visualize multiple MCAP files simultaneously in a single Lichtblick session."
+keywords: [multiple files, mcap, multi-file, parallel playback, session]
 ---
 
 # Multiple files

--- a/docs/experimental-features/introduction.md
+++ b/docs/experimental-features/introduction.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: "Experimental Features"
 description: "Early-stage features available for testing and feedback in Lichtblick."
+keywords: [experimental, beta, preview, features, testing, feedback]
 ---
 
 # Experimental Features

--- a/docs/experimental-features/introduction.md
+++ b/docs/experimental-features/introduction.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 1
+title: "Experimental Features"
+description: "Early-stage features available for testing and feedback in Lichtblick."
+---
+
 # Experimental Features
 
 :::caution

--- a/docs/extensions/extension-api/custom-camera-models.md
+++ b/docs/extensions/extension-api/custom-camera-models.md
@@ -2,6 +2,7 @@
 sidebar_position: 7
 title: "Custom Camera Models"
 description: "Add support for custom camera projection models such as fisheye lenses in the Image panel."
+keywords: [camera model, fisheye, projection, distortion, calibration, image panel, typescript, extension]
 ---
 
 # Custom Camera Models

--- a/docs/extensions/extension-api/custom-camera-models.md
+++ b/docs/extensions/extension-api/custom-camera-models.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 7
+title: "Custom Camera Models"
+description: "Add support for custom camera projection models such as fisheye lenses in the Image panel."
 ---
 
 # Custom Camera Models

--- a/docs/extensions/extension-api/extension-context.md
+++ b/docs/extensions/extension-api/extension-context.md
@@ -2,6 +2,7 @@
 sidebar_position: 2
 title: "ExtensionContext"
 description: "API reference for the ExtensionContext passed to your extension's activate() function."
+keywords: [extension context, activate, api, panels, converters, aliases, typescript]
 ---
 
 # ExtensionContext

--- a/docs/extensions/extension-api/extension-context.md
+++ b/docs/extensions/extension-api/extension-context.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 2
+title: "ExtensionContext"
+description: "API reference for the ExtensionContext passed to your extension's activate() function."
 ---
 
 # ExtensionContext

--- a/docs/extensions/extension-api/extension-module.md
+++ b/docs/extensions/extension-api/extension-module.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 1
+title: "ExtensionModule"
+description: "Entry point for a Lichtblick extension, defining the activate() function called on load."
 ---
 
 # ExtensionModule

--- a/docs/extensions/extension-api/extension-module.md
+++ b/docs/extensions/extension-api/extension-module.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: "ExtensionModule"
 description: "Entry point for a Lichtblick extension, defining the activate() function called on load."
+keywords: [extension module, activate, entry point, typescript, api, extension lifecycle]
 ---
 
 # ExtensionModule

--- a/docs/extensions/extension-api/introduction.md
+++ b/docs/extensions/extension-api/introduction.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 0
+title: "Extension API"
+description: "API reference for the @lichtblick/suite package used to build Lichtblick extensions."
+---
+
 # Extension API
 
 The [`@lichtblick/suite`](https://www.npmjs.com/package/@lichtblick/suite) package provides type definitions and helpers for building Lichtblick extensions.

--- a/docs/extensions/extension-api/introduction.md
+++ b/docs/extensions/extension-api/introduction.md
@@ -2,6 +2,7 @@
 sidebar_position: 0
 title: "Extension API"
 description: "API reference for the @lichtblick/suite package used to build Lichtblick extensions."
+keywords: [extension api, lichtblick/suite, typescript, api reference, sdk, developer]
 ---
 
 # Extension API

--- a/docs/extensions/extension-api/message-converters.md
+++ b/docs/extensions/extension-api/message-converters.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 5
+title: "Message Converters"
+description: "Transform messages from one schema to another using Lichtblick message converter extensions."
 ---
 
 # Message Converters

--- a/docs/extensions/extension-api/message-converters.md
+++ b/docs/extensions/extension-api/message-converters.md
@@ -2,6 +2,7 @@
 sidebar_position: 5
 title: "Message Converters"
 description: "Transform messages from one schema to another using Lichtblick message converter extensions."
+keywords: [message converters, schema, transform, extension, typescript, api, custom messages]
 ---
 
 # Message Converters

--- a/docs/extensions/extension-api/other-types.md
+++ b/docs/extensions/extension-api/other-types.md
@@ -2,6 +2,7 @@
 sidebar_position: 10
 title: "Other Types"
 description: "Reference for all public types exported from the @lichtblick/suite package."
+keywords: [types, api reference, typescript, lichtblick/suite, public types, interfaces]
 ---
 
 # Other types

--- a/docs/extensions/extension-api/other-types.md
+++ b/docs/extensions/extension-api/other-types.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 10
+title: "Other Types"
+description: "Reference for all public types exported from the @lichtblick/suite package."
 ---
 
 # Other types

--- a/docs/extensions/extension-api/panel-extension-context.md
+++ b/docs/extensions/extension-api/panel-extension-context.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 3
+title: "PanelExtensionContext"
+description: "API reference for PanelExtensionContext, used to interact with Lichtblick from a custom panel."
 ---
 
 # PanelExtensionContext

--- a/docs/extensions/extension-api/panel-extension-context.md
+++ b/docs/extensions/extension-api/panel-extension-context.md
@@ -2,6 +2,7 @@
 sidebar_position: 3
 title: "PanelExtensionContext"
 description: "API reference for PanelExtensionContext, used to interact with Lichtblick from a custom panel."
+keywords: [panel extension context, custom panel, subscribe, render, api, typescript, messages]
 ---
 
 # PanelExtensionContext

--- a/docs/extensions/extension-api/settings-api.md
+++ b/docs/extensions/extension-api/settings-api.md
@@ -2,6 +2,7 @@
 sidebar_position: 6
 title: "Settings API"
 description: "Attach per-topic settings UI to message converters using the Lichtblick Settings API."
+keywords: [settings api, per-topic settings, message converter, ui, typescript, api]
 ---
 
 # Settings API

--- a/docs/extensions/extension-api/settings-api.md
+++ b/docs/extensions/extension-api/settings-api.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 6
+title: "Settings API"
+description: "Attach per-topic settings UI to message converters using the Lichtblick Settings API."
 ---
 
 # Settings API

--- a/docs/extensions/extension-api/settings-tree.md
+++ b/docs/extensions/extension-api/settings-tree.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 4
+title: "Settings Tree"
+description: "Render a settings UI for your panel or message converter using a declarative settings tree."
 ---
 
 # Settings Tree

--- a/docs/extensions/extension-api/settings-tree.md
+++ b/docs/extensions/extension-api/settings-tree.md
@@ -2,6 +2,7 @@
 sidebar_position: 4
 title: "Settings Tree"
 description: "Render a settings UI for your panel or message converter using a declarative settings tree."
+keywords: [settings tree, settings ui, panel settings, declarative, api, typescript]
 ---
 
 # Settings Tree

--- a/docs/extensions/extension-api/topic-aliases.md
+++ b/docs/extensions/extension-api/topic-aliases.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 8
+title: "Topic Aliases"
+description: "Expose friendly or standardized topic names without modifying the underlying data source."
 ---
 
 # Topic Aliases

--- a/docs/extensions/extension-api/topic-aliases.md
+++ b/docs/extensions/extension-api/topic-aliases.md
@@ -2,6 +2,7 @@
 sidebar_position: 8
 title: "Topic Aliases"
 description: "Expose friendly or standardized topic names without modifying the underlying data source."
+keywords: [topic aliases, topics, extension, api, typescript, renaming, remapping]
 ---
 
 # Topic Aliases

--- a/docs/extensions/introduction.md
+++ b/docs/extensions/introduction.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 0
+title: "Extensions"
+description: "Extend Lichtblick with custom panels, message converters, and topic aliases."
+---
+
 # Extensions
 
 Extend Lichtblick's capabilities with custom extensions to better support your team's unique workflows. Build bespoke panels, convert custom messages to Lichtblick-supported schemas, and alias topic names for easy visualization.

--- a/docs/extensions/introduction.md
+++ b/docs/extensions/introduction.md
@@ -2,6 +2,7 @@
 sidebar_position: 0
 title: "Extensions"
 description: "Extend Lichtblick with custom panels, message converters, and topic aliases."
+keywords: [extensions, plugins, custom panels, message converters, topic aliases, typescript, developer]
 ---
 
 # Extensions

--- a/docs/extensions/local-development.md
+++ b/docs/extensions/local-development.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: "Local Development"
 description: "Set up a local Lichtblick extension project for development and testing."
+keywords: [local development, extension, scaffold, npm, typescript, testing, setup]
 ---
 
 # Local Development

--- a/docs/extensions/local-development.md
+++ b/docs/extensions/local-development.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 1
+title: "Local Development"
+description: "Set up a local Lichtblick extension project for development and testing."
 ---
 
 # Local Development

--- a/docs/extensions/publish-extensions.md
+++ b/docs/extensions/publish-extensions.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 2
+title: "Publishing Extensions"
+description: "Build and share Lichtblick extension packages with your team."
 ---
 
 # Publishing Extensions

--- a/docs/extensions/publish-extensions.md
+++ b/docs/extensions/publish-extensions.md
@@ -2,6 +2,7 @@
 sidebar_position: 2
 title: "Publishing Extensions"
 description: "Build and share Lichtblick extension packages with your team."
+keywords: [publish, extensions, package, share, distribution, npm]
 ---
 
 # Publishing Extensions

--- a/docs/initial-information.md
+++ b/docs/initial-information.md
@@ -3,6 +3,7 @@ sidebar_position: 1
 title: Getting Started
 slug: /
 description: "An introduction to Lichtblick and how to get started with the platform."
+keywords: [getting started, introduction, lichtblick, robotics, visualization, overview]
 ---
 
 # Welcome to Lichtblick

--- a/docs/initial-information.md
+++ b/docs/initial-information.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: Getting Started
 slug: /
+description: "An introduction to Lichtblick and how to get started with the platform."
 ---
 
 # Welcome to Lichtblick

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 4
 title: Settings
+description: "Configure language, appearance, and default behavior preferences in Lichtblick."
 ---
 
 # Settings

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -2,6 +2,7 @@
 sidebar_position: 4
 title: Settings
 description: "Configure language, appearance, and default behavior preferences in Lichtblick."
+keywords: [settings, preferences, configuration, language, appearance, theme]
 ---
 
 # Settings

--- a/docs/visualization/alerts.md
+++ b/docs/visualization/alerts.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 7
+title: "Alerts"
+description: "Understand the alert system that surfaces errors, warnings, and info messages during data playback."
+---
+
 # Alerts
 
 Lichtblick's alert system surfaces issues that occur during data playback, live connections, and panel processing so the user always knows when something needs attention.

--- a/docs/visualization/alerts.md
+++ b/docs/visualization/alerts.md
@@ -2,6 +2,7 @@
 sidebar_position: 7
 title: "Alerts"
 description: "Understand the alert system that surfaces errors, warnings, and info messages during data playback."
+keywords: [alerts, errors, warnings, diagnostics, playback, notifications, status]
 ---
 
 # Alerts

--- a/docs/visualization/annotate-ros-enum-fields.md
+++ b/docs/visualization/annotate-ros-enum-fields.md
@@ -2,6 +2,7 @@
 sidebar_position: 10
 title: "Annotating ROS Enum Fields"
 description: "Display ROS message constants as named enum values in Lichtblick panels."
+keywords: [ros, enums, message constants, annotations, fields, visualization]
 ---
 
 # Annotating ROS Enum Fields

--- a/docs/visualization/annotate-ros-enum-fields.md
+++ b/docs/visualization/annotate-ros-enum-fields.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 10
+title: "Annotating ROS Enum Fields"
+description: "Display ROS message constants as named enum values in Lichtblick panels."
+---
+
 # Annotating ROS Enum Fields
 
 ROS messages do not natively support enumerations, but Lichtblick provides two ways to treat constant values as enums: using a separate enum message or applying inline annotations.

--- a/docs/visualization/introduction.md
+++ b/docs/visualization/introduction.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 1
+title: "Visualization"
+description: "Overview of Lichtblick's visualization tools for analyzing and interpreting robotics data."
+---
+
 # Visualization
 
 Lichtblick offers a comprehensive suite of visualization tools to help you analyze and interpret your robotics data effectively.

--- a/docs/visualization/introduction.md
+++ b/docs/visualization/introduction.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: "Visualization"
 description: "Overview of Lichtblick's visualization tools for analyzing and interpreting robotics data."
+keywords: [visualization, panels, robotics, data analysis, ros, mcap, overview]
 ---
 
 # Visualization

--- a/docs/visualization/layouts.md
+++ b/docs/visualization/layouts.md
@@ -2,6 +2,7 @@
 sidebar_position: 3
 title: "Layouts"
 description: "Create, save, and share customized workspace layouts for recurring tasks and team collaboration."
+keywords: [layouts, workspace, panels, save, share, collaboration, template]
 ---
 
 # Layouts

--- a/docs/visualization/layouts.md
+++ b/docs/visualization/layouts.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 3
+title: "Layouts"
+description: "Create, save, and share customized workspace layouts for recurring tasks and team collaboration."
+---
+
 # Layouts
 
 Lichtblick layouts enable users to design and save customized workspaces tailored to specific tasks or workflows. These layouts can be reused for recurring projects or shared with team members working on similar challenges.

--- a/docs/visualization/message-path-syntax.md
+++ b/docs/visualization/message-path-syntax.md
@@ -2,6 +2,7 @@
 sidebar_position: 5
 title: "Message Path Syntax"
 description: "Syntax reference for accessing specific fields within messages using Lichtblick's path notation."
+keywords: [message path, syntax, fields, topics, data access, query, filtering]
 ---
 
 # Message Path Syntax

--- a/docs/visualization/message-path-syntax.md
+++ b/docs/visualization/message-path-syntax.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 5
+title: "Message Path Syntax"
+description: "Syntax reference for accessing specific fields within messages using Lichtblick's path notation."
+---
+
 # Message Path Syntax
 
 In Lichtblick, message path syntax is utilized to precisely access specific data within your messages.

--- a/docs/visualization/message-schemas/arrow-primitive.md
+++ b/docs/visualization/message-schemas/arrow-primitive.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 2
+title: "ArrowPrimitive"
+description: "Schema for a visual arrow primitive used to indicate direction or orientation in 3D space."
+---
+
 # ArrowPrimitive
 
 Represents a visual arrow used to indicate direction or orientation in 3D space.

--- a/docs/visualization/message-schemas/arrow-primitive.md
+++ b/docs/visualization/message-schemas/arrow-primitive.md
@@ -2,6 +2,7 @@
 sidebar_position: 2
 title: "ArrowPrimitive"
 description: "Schema for a visual arrow primitive used to indicate direction or orientation in 3D space."
+keywords: [arrow, primitive, 3d, direction, orientation, scene entity, visualization]
 ---
 
 # ArrowPrimitive

--- a/docs/visualization/message-schemas/built-in-types.md
+++ b/docs/visualization/message-schemas/built-in-types.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 3
+title: "Built-in Types"
+description: "Primitive types that serve as the building blocks of Foxglove's supported message schemas."
+---
+
 # Built-in types
 
 Primitive types are the building blocks of Foxglove's supported message schemas.

--- a/docs/visualization/message-schemas/built-in-types.md
+++ b/docs/visualization/message-schemas/built-in-types.md
@@ -2,6 +2,7 @@
 sidebar_position: 3
 title: "Built-in Types"
 description: "Primitive types that serve as the building blocks of Foxglove's supported message schemas."
+keywords: [built-in types, primitive types, bool, int, float, string, bytes, schema]
 ---
 
 # Built-in types

--- a/docs/visualization/message-schemas/camera-calibration.md
+++ b/docs/visualization/message-schemas/camera-calibration.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 4
+title: "CameraCalibration"
+description: "Schema for camera intrinsic and extrinsic calibration parameters."
+---
+
 # CameraCalibration
 
 Contains intrinsic and extrinsic calibration parameters for a camera.

--- a/docs/visualization/message-schemas/camera-calibration.md
+++ b/docs/visualization/message-schemas/camera-calibration.md
@@ -2,6 +2,7 @@
 sidebar_position: 4
 title: "CameraCalibration"
 description: "Schema for camera intrinsic and extrinsic calibration parameters."
+keywords: [camera calibration, intrinsics, extrinsics, distortion, camera info, ros, image]
 ---
 
 # CameraCalibration

--- a/docs/visualization/message-schemas/circle-annotation.md
+++ b/docs/visualization/message-schemas/circle-annotation.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 5
+title: "CircleAnnotation"
+description: "Schema for a circle annotation overlaid on image data."
+---
+
 # CircleAnnotation
 
 A circle annotation on a 2D image.

--- a/docs/visualization/message-schemas/circle-annotation.md
+++ b/docs/visualization/message-schemas/circle-annotation.md
@@ -2,6 +2,7 @@
 sidebar_position: 5
 title: "CircleAnnotation"
 description: "Schema for a circle annotation overlaid on image data."
+keywords: [circle annotation, image annotation, overlay, 2d, visualization, schema]
 ---
 
 # CircleAnnotation

--- a/docs/visualization/message-schemas/color.md
+++ b/docs/visualization/message-schemas/color.md
@@ -2,6 +2,7 @@
 sidebar_position: 6
 title: "Color"
 description: "Schema for an RGBA color value used across Lichtblick message schemas."
+keywords: [color, rgba, schema, visualization, primitive]
 ---
 
 # Color

--- a/docs/visualization/message-schemas/color.md
+++ b/docs/visualization/message-schemas/color.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 6
+title: "Color"
+description: "Schema for an RGBA color value used across Lichtblick message schemas."
+---
+
 # Color
 
 A color represented in RGBA format.

--- a/docs/visualization/message-schemas/compressed-image.md
+++ b/docs/visualization/message-schemas/compressed-image.md
@@ -2,6 +2,7 @@
 sidebar_position: 7
 title: "CompressedImage"
 description: "Schema for a compressed image (JPEG, PNG, or WebP) for display in the Image panel."
+keywords: [compressed image, jpeg, png, webp, image panel, camera, schema]
 ---
 
 # CompressedImage

--- a/docs/visualization/message-schemas/compressed-image.md
+++ b/docs/visualization/message-schemas/compressed-image.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 7
+title: "CompressedImage"
+description: "Schema for a compressed image (JPEG, PNG, or WebP) for display in the Image panel."
+---
+
 # CompressedImage
 
 A compressed image.

--- a/docs/visualization/message-schemas/compressed-video.md
+++ b/docs/visualization/message-schemas/compressed-video.md
@@ -2,6 +2,7 @@
 sidebar_position: 8
 title: "CompressedVideo"
 description: "Schema for a compressed video frame for streaming display in the Image panel."
+keywords: [compressed video, h264, h265, video streaming, image panel, schema]
 ---
 
 # CompressedVideo

--- a/docs/visualization/message-schemas/compressed-video.md
+++ b/docs/visualization/message-schemas/compressed-video.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 8
+title: "CompressedVideo"
+description: "Schema for a compressed video frame for streaming display in the Image panel."
+---
+
 # CompressedVideo
 
 A single frame of a compressed video bitstream.

--- a/docs/visualization/message-schemas/cube-primitive.md
+++ b/docs/visualization/message-schemas/cube-primitive.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 9
+title: "CubePrimitive"
+description: "Schema for a cube or rectangular box primitive rendered in the 3D panel."
+---
+
 # CubePrimitive
 
 A primitive representing a cube or rectangular prism.

--- a/docs/visualization/message-schemas/cube-primitive.md
+++ b/docs/visualization/message-schemas/cube-primitive.md
@@ -2,6 +2,7 @@
 sidebar_position: 9
 title: "CubePrimitive"
 description: "Schema for a cube or rectangular box primitive rendered in the 3D panel."
+keywords: [cube, box, primitive, 3d, scene entity, visualization, schema]
 ---
 
 # CubePrimitive

--- a/docs/visualization/message-schemas/cylinder-primitive.md
+++ b/docs/visualization/message-schemas/cylinder-primitive.md
@@ -2,6 +2,7 @@
 sidebar_position: 10
 title: "CylinderPrimitive"
 description: "Schema for a cylinder or cone primitive rendered in the 3D panel."
+keywords: [cylinder, cone, primitive, 3d, scene entity, visualization, schema]
 ---
 
 # CylinderPrimitive

--- a/docs/visualization/message-schemas/cylinder-primitive.md
+++ b/docs/visualization/message-schemas/cylinder-primitive.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 10
+title: "CylinderPrimitive"
+description: "Schema for a cylinder or cone primitive rendered in the 3D panel."
+---
+
 # CylinderPrimitive
 
 A primitive representing a cylinder, elliptic cylinder, or truncated cone.

--- a/docs/visualization/message-schemas/enum-line-type.md
+++ b/docs/visualization/message-schemas/enum-line-type.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 11
+title: "LineType"
+description: "Enum defining line rendering styles used in LinePrimitive messages."
+---
+
 # LineType
 
 An enumeration that defines how a set of input points is connected to form lines.

--- a/docs/visualization/message-schemas/enum-line-type.md
+++ b/docs/visualization/message-schemas/enum-line-type.md
@@ -2,6 +2,7 @@
 sidebar_position: 11
 title: "LineType"
 description: "Enum defining line rendering styles used in LinePrimitive messages."
+keywords: [line type, enum, line primitive, rendering, schema, 3d]
 ---
 
 # LineType

--- a/docs/visualization/message-schemas/enum-log-level.md
+++ b/docs/visualization/message-schemas/enum-log-level.md
@@ -2,6 +2,7 @@
 sidebar_position: 12
 title: "LogLevel"
 description: "Enum defining log severity levels used in Log messages."
+keywords: [log level, enum, severity, debug, info, warning, error, schema]
 ---
 
 # LogLevel

--- a/docs/visualization/message-schemas/enum-log-level.md
+++ b/docs/visualization/message-schemas/enum-log-level.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 12
+title: "LogLevel"
+description: "Enum defining log severity levels used in Log messages."
+---
+
 # LogLevel
 
 The severity level assigned to a log entry.

--- a/docs/visualization/message-schemas/enum-numeric-type.md
+++ b/docs/visualization/message-schemas/enum-numeric-type.md
@@ -2,6 +2,7 @@
 sidebar_position: 13
 title: "NumericType"
 description: "Enum defining numeric data types used in PackedElementField messages."
+keywords: [numeric type, enum, data type, int, float, packed element, schema]
 ---
 
 # NumericType

--- a/docs/visualization/message-schemas/enum-numeric-type.md
+++ b/docs/visualization/message-schemas/enum-numeric-type.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 13
+title: "NumericType"
+description: "Enum defining numeric data types used in PackedElementField messages."
+---
+
 # NumericType
 
 The data type used to represent a numeric value.

--- a/docs/visualization/message-schemas/enum-points-annotation-type.md
+++ b/docs/visualization/message-schemas/enum-points-annotation-type.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 14
+title: "PointsAnnotationType"
+description: "Enum defining rendering styles for point annotations overlaid on image data."
+---
+
 # PointsAnnotationType
 
 Defines how a set of points should be rendered as an annotation.

--- a/docs/visualization/message-schemas/enum-points-annotation-type.md
+++ b/docs/visualization/message-schemas/enum-points-annotation-type.md
@@ -2,6 +2,7 @@
 sidebar_position: 14
 title: "PointsAnnotationType"
 description: "Enum defining rendering styles for point annotations overlaid on image data."
+keywords: [points annotation type, enum, rendering, image annotation, schema]
 ---
 
 # PointsAnnotationType

--- a/docs/visualization/message-schemas/enum-position-covariance-type.md
+++ b/docs/visualization/message-schemas/enum-position-covariance-type.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 15
+title: "PositionCovarianceType"
+description: "Enum defining how position covariance data is represented in LocationFix messages."
+---
+
 # PositionCovarianceType
 
 Describes how the position covariance data was obtained or estimated.

--- a/docs/visualization/message-schemas/enum-position-covariance-type.md
+++ b/docs/visualization/message-schemas/enum-position-covariance-type.md
@@ -2,6 +2,7 @@
 sidebar_position: 15
 title: "PositionCovarianceType"
 description: "Enum defining how position covariance data is represented in LocationFix messages."
+keywords: [position covariance type, enum, gps, location fix, schema]
 ---
 
 # PositionCovarianceType

--- a/docs/visualization/message-schemas/enum-scene-entity-deletion-type.md
+++ b/docs/visualization/message-schemas/enum-scene-entity-deletion-type.md
@@ -2,6 +2,7 @@
 sidebar_position: 16
 title: "SceneEntityDeletionType"
 description: "Enum defining deletion scope for SceneEntityDeletion messages in the 3D panel."
+keywords: [scene entity deletion type, enum, 3d panel, deletion, schema]
 ---
 
 # SceneEntityDeletionType

--- a/docs/visualization/message-schemas/enum-scene-entity-deletion-type.md
+++ b/docs/visualization/message-schemas/enum-scene-entity-deletion-type.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 16
+title: "SceneEntityDeletionType"
+description: "Enum defining deletion scope for SceneEntityDeletion messages in the 3D panel."
+---
+
 # SceneEntityDeletionType
 
 An enumeration that specifies the scope of entities targeted by a `SceneEntityDeletion` command.

--- a/docs/visualization/message-schemas/frame-transform.md
+++ b/docs/visualization/message-schemas/frame-transform.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 17
+title: "FrameTransform"
+description: "Schema for a coordinate frame transform defining the relationship between two frames."
+---
+
 # FrameTransform
 
 A transform between two reference frames in 3D space.

--- a/docs/visualization/message-schemas/frame-transform.md
+++ b/docs/visualization/message-schemas/frame-transform.md
@@ -2,6 +2,7 @@
 sidebar_position: 17
 title: "FrameTransform"
 description: "Schema for a coordinate frame transform defining the relationship between two frames."
+keywords: [frame transform, tf, coordinate frames, transforms, 3d, ros, schema]
 ---
 
 # FrameTransform

--- a/docs/visualization/message-schemas/frame-transforms.md
+++ b/docs/visualization/message-schemas/frame-transforms.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 18
+title: "FrameTransforms"
+description: "Schema for a collection of coordinate frame transforms used in the 3D panel."
+---
+
 # FrameTransforms
 
 An array of [`FrameTransform`](./frame-transform.md) messages.

--- a/docs/visualization/message-schemas/frame-transforms.md
+++ b/docs/visualization/message-schemas/frame-transforms.md
@@ -2,6 +2,7 @@
 sidebar_position: 18
 title: "FrameTransforms"
 description: "Schema for a collection of coordinate frame transforms used in the 3D panel."
+keywords: [frame transforms, tf, coordinate frames, transforms, 3d, ros, schema]
 ---
 
 # FrameTransforms

--- a/docs/visualization/message-schemas/geojson.md
+++ b/docs/visualization/message-schemas/geojson.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 19
+title: "GeoJSON"
+description: "Schema for GeoJSON data displayed as geographic overlays in the Map panel."
+---
+
 # GeoJSON
 
 GeoJSON data for annotating maps.

--- a/docs/visualization/message-schemas/geojson.md
+++ b/docs/visualization/message-schemas/geojson.md
@@ -2,6 +2,7 @@
 sidebar_position: 19
 title: "GeoJSON"
 description: "Schema for GeoJSON data displayed as geographic overlays in the Map panel."
+keywords: [geojson, map, geographic, gps, location, overlay, schema]
 ---
 
 # GeoJSON

--- a/docs/visualization/message-schemas/grid.md
+++ b/docs/visualization/message-schemas/grid.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 20
+title: "Grid"
+description: "Schema for a 2D grid of data cells displayed as a surface or heatmap in the 3D panel."
+---
+
 # Grid
 
 A 2D grid of data.

--- a/docs/visualization/message-schemas/grid.md
+++ b/docs/visualization/message-schemas/grid.md
@@ -2,6 +2,7 @@
 sidebar_position: 20
 title: "Grid"
 description: "Schema for a 2D grid of data cells displayed as a surface or heatmap in the 3D panel."
+keywords: [grid, heatmap, 2d, occupancy, sensor, 3d panel, schema]
 ---
 
 # Grid

--- a/docs/visualization/message-schemas/image-annotations.md
+++ b/docs/visualization/message-schemas/image-annotations.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 21
+title: "ImageAnnotations"
+description: "Schema for a collection of annotations (circles, points, text) overlaid on image data."
+---
+
 # ImageAnnotations
 
 Array of annotations for a 2D image.

--- a/docs/visualization/message-schemas/image-annotations.md
+++ b/docs/visualization/message-schemas/image-annotations.md
@@ -2,6 +2,7 @@
 sidebar_position: 21
 title: "ImageAnnotations"
 description: "Schema for a collection of annotations (circles, points, text) overlaid on image data."
+keywords: [image annotations, overlay, circle, points, text, image panel, schema]
 ---
 
 # ImageAnnotations

--- a/docs/visualization/message-schemas/introduction.md
+++ b/docs/visualization/message-schemas/introduction.md
@@ -3,6 +3,7 @@ slug: /visualization/message-schemas
 sidebar_position: 1
 title: "Message Schemas"
 description: "Reference for Lichtblick's structured message schemas used to drive accurate data visualization."
+keywords: [message schemas, foxglove, ros, mcap, protobuf, flatbuffers, json, schema reference]
 ---
 
 # Message Schemas

--- a/docs/visualization/message-schemas/introduction.md
+++ b/docs/visualization/message-schemas/introduction.md
@@ -1,5 +1,8 @@
 ---
 slug: /visualization/message-schemas
+sidebar_position: 1
+title: "Message Schemas"
+description: "Reference for Lichtblick's structured message schemas used to drive accurate data visualization."
 ---
 
 # Message Schemas

--- a/docs/visualization/message-schemas/key-value-pair.md
+++ b/docs/visualization/message-schemas/key-value-pair.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 22
+title: "KeyValuePair"
+description: "Schema for a generic key-value pair used in SceneEntity metadata."
+---
+
 # KeyValuePair
 
 A key with its associated value.

--- a/docs/visualization/message-schemas/key-value-pair.md
+++ b/docs/visualization/message-schemas/key-value-pair.md
@@ -2,6 +2,7 @@
 sidebar_position: 22
 title: "KeyValuePair"
 description: "Schema for a generic key-value pair used in SceneEntity metadata."
+keywords: [key value pair, metadata, scene entity, schema]
 ---
 
 # KeyValuePair

--- a/docs/visualization/message-schemas/laser-scan.md
+++ b/docs/visualization/message-schemas/laser-scan.md
@@ -2,6 +2,7 @@
 sidebar_position: 23
 title: "LaserScan"
 description: "Schema for a single 2D or 3D laser scan displayed as a point cloud in the 3D panel."
+keywords: [laser scan, lidar, point cloud, sensor, 2d, 3d, ros, schema]
 ---
 
 # LaserScan

--- a/docs/visualization/message-schemas/laser-scan.md
+++ b/docs/visualization/message-schemas/laser-scan.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 23
+title: "LaserScan"
+description: "Schema for a single 2D or 3D laser scan displayed as a point cloud in the 3D panel."
+---
+
 # LaserScan
 
 Single scan from a planar laser range-finder

--- a/docs/visualization/message-schemas/line-primitive.md
+++ b/docs/visualization/message-schemas/line-primitive.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 24
+title: "LinePrimitive"
+description: "Schema for a line or line list primitive rendered in the 3D panel."
+---
+
 # LinePrimitive
 
 A primitive representing a series of points connected by lines.

--- a/docs/visualization/message-schemas/line-primitive.md
+++ b/docs/visualization/message-schemas/line-primitive.md
@@ -2,6 +2,7 @@
 sidebar_position: 24
 title: "LinePrimitive"
 description: "Schema for a line or line list primitive rendered in the 3D panel."
+keywords: [line primitive, path, polyline, 3d, scene entity, schema]
 ---
 
 # LinePrimitive

--- a/docs/visualization/message-schemas/location-fix.md
+++ b/docs/visualization/message-schemas/location-fix.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 25
+title: "LocationFix"
+description: "Schema for a GPS fix message displayed as a position on the Map panel."
+---
+
 # LocationFix
 
 A navigation satellite fix for any Global Navigation Satellite System

--- a/docs/visualization/message-schemas/location-fix.md
+++ b/docs/visualization/message-schemas/location-fix.md
@@ -2,6 +2,7 @@
 sidebar_position: 25
 title: "LocationFix"
 description: "Schema for a GPS fix message displayed as a position on the Map panel."
+keywords: [location fix, gps, gnss, coordinates, map panel, schema]
 ---
 
 # LocationFix

--- a/docs/visualization/message-schemas/log.md
+++ b/docs/visualization/message-schemas/log.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 26
+title: "Log"
+description: "Schema for a log message with severity level, displayed in the Log panel."
+---
+
 # Log
 
 A log message

--- a/docs/visualization/message-schemas/log.md
+++ b/docs/visualization/message-schemas/log.md
@@ -2,6 +2,7 @@
 sidebar_position: 26
 title: "Log"
 description: "Schema for a log message with severity level, displayed in the Log panel."
+keywords: [log, logging, severity, debug, info, warning, error, schema]
 ---
 
 # Log

--- a/docs/visualization/message-schemas/model-primitive.md
+++ b/docs/visualization/message-schemas/model-primitive.md
@@ -2,6 +2,7 @@
 sidebar_position: 27
 title: "ModelPrimitive"
 description: "Schema for a 3D model primitive (glTF/GLB) rendered in the 3D panel."
+keywords: [model, gltf, glb, 3d model, scene entity, primitive, schema]
 ---
 
 # ModelPrimitive

--- a/docs/visualization/message-schemas/model-primitive.md
+++ b/docs/visualization/message-schemas/model-primitive.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 27
+title: "ModelPrimitive"
+description: "Schema for a 3D model primitive (glTF/GLB) rendered in the 3D panel."
+---
+
 # ModelPrimitive
 
 A primitive representing a 3D model file loaded from an external URL or embedded data.

--- a/docs/visualization/message-schemas/packed-element-field.md
+++ b/docs/visualization/message-schemas/packed-element-field.md
@@ -2,6 +2,7 @@
 sidebar_position: 28
 title: "PackedElementField"
 description: "Schema for a field descriptor used in packed point cloud data structures."
+keywords: [packed element field, point cloud, data structure, field descriptor, schema]
 ---
 
 # PackedElementField

--- a/docs/visualization/message-schemas/packed-element-field.md
+++ b/docs/visualization/message-schemas/packed-element-field.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 28
+title: "PackedElementField"
+description: "Schema for a field descriptor used in packed point cloud data structures."
+---
+
 # PackedElementField
 
 A field present within each element in a byte array of packed elements.

--- a/docs/visualization/message-schemas/point-cloud.md
+++ b/docs/visualization/message-schemas/point-cloud.md
@@ -2,6 +2,7 @@
 sidebar_position: 29
 title: "PointCloud"
 description: "Schema for a point cloud rendered as a 3D scatter plot in the 3D panel."
+keywords: [point cloud, lidar, sensor data, 3d, scatter plot, mcap, ros, schema]
 ---
 
 # PointCloud

--- a/docs/visualization/message-schemas/point-cloud.md
+++ b/docs/visualization/message-schemas/point-cloud.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 29
+title: "PointCloud"
+description: "Schema for a point cloud rendered as a 3D scatter plot in the 3D panel."
+---
+
 # PointCloud
 
 A collection of N-dimensional points, which may contain additional fields with information like normals, intensity, etc.

--- a/docs/visualization/message-schemas/point2.md
+++ b/docs/visualization/message-schemas/point2.md
@@ -2,6 +2,7 @@
 sidebar_position: 30
 title: "Point2"
 description: "Schema for a 2D point with x and y coordinates."
+keywords: [point2, 2d point, coordinates, x, y, schema]
 ---
 
 # Point2

--- a/docs/visualization/message-schemas/point2.md
+++ b/docs/visualization/message-schemas/point2.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 30
+title: "Point2"
+description: "Schema for a 2D point with x and y coordinates."
+---
+
 # Point2
 
 A point representing a position in 2D space.

--- a/docs/visualization/message-schemas/point3.md
+++ b/docs/visualization/message-schemas/point3.md
@@ -2,6 +2,7 @@
 sidebar_position: 31
 title: "Point3"
 description: "Schema for a 3D point with x, y, and z coordinates."
+keywords: [point3, 3d point, coordinates, x, y, z, schema]
 ---
 
 # Point3

--- a/docs/visualization/message-schemas/point3.md
+++ b/docs/visualization/message-schemas/point3.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 31
+title: "Point3"
+description: "Schema for a 3D point with x, y, and z coordinates."
+---
+
 # Point3
 
 A point representing a position in 3D space.

--- a/docs/visualization/message-schemas/points-annotation.md
+++ b/docs/visualization/message-schemas/points-annotation.md
@@ -2,6 +2,7 @@
 sidebar_position: 32
 title: "PointsAnnotation"
 description: "Schema for a points annotation overlaid on image data, supporting various rendering styles."
+keywords: [points annotation, image overlay, keypoints, markers, 2d, schema]
 ---
 
 # PointsAnnotation

--- a/docs/visualization/message-schemas/points-annotation.md
+++ b/docs/visualization/message-schemas/points-annotation.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 32
+title: "PointsAnnotation"
+description: "Schema for a points annotation overlaid on image data, supporting various rendering styles."
+---
+
 # PointsAnnotation
 
 An array of points on a 2D image.

--- a/docs/visualization/message-schemas/pose-in-frame.md
+++ b/docs/visualization/message-schemas/pose-in-frame.md
@@ -2,6 +2,7 @@
 sidebar_position: 33
 title: "PoseInFrame"
 description: "Schema for a pose (position and orientation) associated with a specific coordinate frame."
+keywords: [pose in frame, position, orientation, coordinate frame, 3d, schema]
 ---
 
 # PoseInFrame

--- a/docs/visualization/message-schemas/pose-in-frame.md
+++ b/docs/visualization/message-schemas/pose-in-frame.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 33
+title: "PoseInFrame"
+description: "Schema for a pose (position and orientation) associated with a specific coordinate frame."
+---
+
 # PoseInFrame
 
 A position and orientation for an object or reference frame in 3D space.

--- a/docs/visualization/message-schemas/pose.md
+++ b/docs/visualization/message-schemas/pose.md
@@ -2,6 +2,7 @@
 sidebar_position: 34
 title: "Pose"
 description: "Schema for a position and quaternion orientation in 3D space."
+keywords: [pose, position, orientation, quaternion, 3d, transforms, schema]
 ---
 
 # Pose

--- a/docs/visualization/message-schemas/pose.md
+++ b/docs/visualization/message-schemas/pose.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 34
+title: "Pose"
+description: "Schema for a position and quaternion orientation in 3D space."
+---
+
 # Pose
 
 A position and orientation for an object or reference frame in 3D space.

--- a/docs/visualization/message-schemas/poses-in-frame.md
+++ b/docs/visualization/message-schemas/poses-in-frame.md
@@ -2,6 +2,7 @@
 sidebar_position: 35
 title: "PosesInFrame"
 description: "Schema for a collection of poses in a single coordinate frame, rendered in the 3D panel."
+keywords: [poses in frame, trajectory, position, orientation, 3d panel, schema]
 ---
 
 # PosesInFrame

--- a/docs/visualization/message-schemas/poses-in-frame.md
+++ b/docs/visualization/message-schemas/poses-in-frame.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 35
+title: "PosesInFrame"
+description: "Schema for a collection of poses in a single coordinate frame, rendered in the 3D panel."
+---
+
 # PosesInFrame
 
 An array of timestamped poses for an object or reference frame in 3D space.

--- a/docs/visualization/message-schemas/quaternion.md
+++ b/docs/visualization/message-schemas/quaternion.md
@@ -2,6 +2,7 @@
 sidebar_position: 36
 title: "Quaternion"
 description: "Schema for a unit quaternion representing a 3D rotation."
+keywords: [quaternion, rotation, orientation, 3d, math, schema]
 ---
 
 # Quaternion

--- a/docs/visualization/message-schemas/quaternion.md
+++ b/docs/visualization/message-schemas/quaternion.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 36
+title: "Quaternion"
+description: "Schema for a unit quaternion representing a 3D rotation."
+---
+
 # Quaternion
 
 A [quaternion](https://eater.net/quaternions) representing a rotation in 3D.

--- a/docs/visualization/message-schemas/raw-image.md
+++ b/docs/visualization/message-schemas/raw-image.md
@@ -2,6 +2,7 @@
 sidebar_position: 37
 title: "RawImage"
 description: "Schema for an uncompressed raw image for display in the Image panel."
+keywords: [raw image, uncompressed, camera, image panel, sensor, schema]
 ---
 
 # RawImage

--- a/docs/visualization/message-schemas/raw-image.md
+++ b/docs/visualization/message-schemas/raw-image.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 37
+title: "RawImage"
+description: "Schema for an uncompressed raw image for display in the Image panel."
+---
+
 # RawImage
 
 A raw image.

--- a/docs/visualization/message-schemas/scene-entity-deletion.md
+++ b/docs/visualization/message-schemas/scene-entity-deletion.md
@@ -2,6 +2,7 @@
 sidebar_position: 38
 title: "SceneEntityDeletion"
 description: "Schema for removing one or all scene entities from the 3D panel at a given timestamp."
+keywords: [scene entity deletion, 3d panel, remove, delete, schema]
 ---
 
 # SceneEntityDeletion

--- a/docs/visualization/message-schemas/scene-entity-deletion.md
+++ b/docs/visualization/message-schemas/scene-entity-deletion.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 38
+title: "SceneEntityDeletion"
+description: "Schema for removing one or all scene entities from the 3D panel at a given timestamp."
+---
+
 # SceneEntityDeletion
 
 An instruction to delete entities that were previously added to the scene.

--- a/docs/visualization/message-schemas/scene-entity.md
+++ b/docs/visualization/message-schemas/scene-entity.md
@@ -2,6 +2,7 @@
 sidebar_position: 39
 title: "SceneEntity"
 description: "Schema for a collection of 3D primitives grouped as a named entity in the 3D panel."
+keywords: [scene entity, 3d, primitives, markers, visualization, schema]
 ---
 
 # SceneEntity

--- a/docs/visualization/message-schemas/scene-entity.md
+++ b/docs/visualization/message-schemas/scene-entity.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 39
+title: "SceneEntity"
+description: "Schema for a collection of 3D primitives grouped as a named entity in the 3D panel."
+---
+
 # SceneEntity
 
 A graphical object within a 3D scene. An entity can consist of several primitives that all operate within the same coordinate frame.

--- a/docs/visualization/message-schemas/scene-update.md
+++ b/docs/visualization/message-schemas/scene-update.md
@@ -2,6 +2,7 @@
 sidebar_position: 40
 title: "SceneUpdate"
 description: "Schema for adding or deleting scene entities in the 3D panel."
+keywords: [scene update, 3d panel, entities, add, delete, schema]
 ---
 
 # SceneUpdate

--- a/docs/visualization/message-schemas/scene-update.md
+++ b/docs/visualization/message-schemas/scene-update.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 40
+title: "SceneUpdate"
+description: "Schema for adding or deleting scene entities in the 3D panel."
+---
+
 # SceneUpdate
 
 A message used to modify the set of entities rendered in a 3D scene.

--- a/docs/visualization/message-schemas/sphere-primitive.md
+++ b/docs/visualization/message-schemas/sphere-primitive.md
@@ -2,6 +2,7 @@
 sidebar_position: 41
 title: "SpherePrimitive"
 description: "Schema for a sphere or ellipsoid primitive rendered in the 3D panel."
+keywords: [sphere, ellipsoid, primitive, 3d, scene entity, schema]
 ---
 
 # SpherePrimitive

--- a/docs/visualization/message-schemas/sphere-primitive.md
+++ b/docs/visualization/message-schemas/sphere-primitive.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 41
+title: "SpherePrimitive"
+description: "Schema for a sphere or ellipsoid primitive rendered in the 3D panel."
+---
+
 # SpherePrimitive
 
 A primitive that describes a spherical or ellipsoidal shape.

--- a/docs/visualization/message-schemas/text-annotation.md
+++ b/docs/visualization/message-schemas/text-annotation.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 42
+title: "TextAnnotation"
+description: "Schema for a text label annotation overlaid on image data."
+---
+
 # TextAnnotation
 
 A textual annotation overlaid on a 2D image.

--- a/docs/visualization/message-schemas/text-annotation.md
+++ b/docs/visualization/message-schemas/text-annotation.md
@@ -2,6 +2,7 @@
 sidebar_position: 42
 title: "TextAnnotation"
 description: "Schema for a text label annotation overlaid on image data."
+keywords: [text annotation, label, image overlay, 2d, schema]
 ---
 
 # TextAnnotation

--- a/docs/visualization/message-schemas/text-primitive.md
+++ b/docs/visualization/message-schemas/text-primitive.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 43
+title: "TextPrimitive"
+description: "Schema for a text label primitive rendered in the 3D panel."
+---
+
 # TextPrimitive
 
 A primitive used to display a text label in a 3D scene.

--- a/docs/visualization/message-schemas/text-primitive.md
+++ b/docs/visualization/message-schemas/text-primitive.md
@@ -2,6 +2,7 @@
 sidebar_position: 43
 title: "TextPrimitive"
 description: "Schema for a text label primitive rendered in the 3D panel."
+keywords: [text primitive, label, 3d, scene entity, schema]
 ---
 
 # TextPrimitive

--- a/docs/visualization/message-schemas/triangle-list-primitive.md
+++ b/docs/visualization/message-schemas/triangle-list-primitive.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 44
+title: "TriangleListPrimitive"
+description: "Schema for a triangle mesh primitive rendered in the 3D panel."
+---
+
 # TriangleListPrimitive
 
 A primitive that defines a collection of triangles or a surface constructed from a triangular mesh.

--- a/docs/visualization/message-schemas/triangle-list-primitive.md
+++ b/docs/visualization/message-schemas/triangle-list-primitive.md
@@ -2,6 +2,7 @@
 sidebar_position: 44
 title: "TriangleListPrimitive"
 description: "Schema for a triangle mesh primitive rendered in the 3D panel."
+keywords: [triangle list, mesh, surface, 3d, scene entity, primitive, schema]
 ---
 
 # TriangleListPrimitive

--- a/docs/visualization/message-schemas/vector2.md
+++ b/docs/visualization/message-schemas/vector2.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 45
+title: "Vector2"
+description: "Schema for a 2D vector with x and y components."
+---
+
 # Vector2
 
 A directional vector defined in two-dimensional space.

--- a/docs/visualization/message-schemas/vector2.md
+++ b/docs/visualization/message-schemas/vector2.md
@@ -2,6 +2,7 @@
 sidebar_position: 45
 title: "Vector2"
 description: "Schema for a 2D vector with x and y components."
+keywords: [vector2, 2d vector, x, y, math, schema]
 ---
 
 # Vector2

--- a/docs/visualization/message-schemas/vector3.md
+++ b/docs/visualization/message-schemas/vector3.md
@@ -2,6 +2,7 @@
 sidebar_position: 46
 title: "Vector3"
 description: "Schema for a 3D vector with x, y, and z components."
+keywords: [vector3, 3d vector, x, y, z, math, schema]
 ---
 
 # Vector3

--- a/docs/visualization/message-schemas/vector3.md
+++ b/docs/visualization/message-schemas/vector3.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 46
+title: "Vector3"
+description: "Schema for a 3D vector with x, y, and z components."
+---
+
 # Vector3
 
 A directional vector defined in three-dimensional space.

--- a/docs/visualization/migrate-from-other-tools.md
+++ b/docs/visualization/migrate-from-other-tools.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 11
+title: "Migrate from Other Tools"
+description: "Map familiar ROS and ROS 2 developer tools to their equivalent Lichtblick panels."
+---
+
 # Migrate from Other Tools
 
 Lichtblick streamlines robotics development by integrating commonly used developer tools into modular panels—providing a unified development environment.

--- a/docs/visualization/migrate-from-other-tools.md
+++ b/docs/visualization/migrate-from-other-tools.md
@@ -2,6 +2,7 @@
 sidebar_position: 11
 title: "Migrate from Other Tools"
 description: "Map familiar ROS and ROS 2 developer tools to their equivalent Lichtblick panels."
+keywords: [migration, foxglove, rviz, rqt, ros, ros2, panels, tools]
 ---
 
 # Migrate from Other Tools

--- a/docs/visualization/open-via-cli.md
+++ b/docs/visualization/open-via-cli.md
@@ -2,6 +2,7 @@
 sidebar_position: 9
 title: "Open via CLI"
 description: "Open local MCAP files directly from the command line using the Lichtblick desktop application."
+keywords: [cli, command line, mcap, desktop, open file, terminal]
 ---
 
 # Open via CLI

--- a/docs/visualization/open-via-cli.md
+++ b/docs/visualization/open-via-cli.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 9
+title: "Open via CLI"
+description: "Open local MCAP files directly from the command line using the Lichtblick desktop application."
+---
+
 # Open via CLI
 
 Easily open local files using the command line by installing the Lichtblick desktop application. This allows you to quickly access .mcap files without manually navigating through the interface.

--- a/docs/visualization/panels/3d-panel.md
+++ b/docs/visualization/panels/3d-panel.md
@@ -1,5 +1,6 @@
 ---
 id: 3d
+sidebar_position: 2
 title: 3D Panel
 description: Visualize robots and environments in 3D — markers, entities, point clouds, URDFs, transforms and more.
 ---

--- a/docs/visualization/panels/3d-panel.md
+++ b/docs/visualization/panels/3d-panel.md
@@ -3,6 +3,7 @@ id: 3d
 sidebar_position: 2
 title: 3D Panel
 description: Visualize robots and environments in 3D — markers, entities, point clouds, URDFs, transforms and more.
+keywords: [3d, visualization, point cloud, lidar, transforms, scene entities, urdf, ros, markers, tf]
 ---
 
 ## Overview

--- a/docs/visualization/panels/gauge-panel.md
+++ b/docs/visualization/panels/gauge-panel.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 3
+title: "Gauge Panel"
+description: "Display numeric topic values on a customizable dial gauge for at-a-glance scalar monitoring."
+---
+
 # Gauge Panel
 
 The Gauge Panel in Lichtblick allows you to visualize numeric values from incoming topic [message paths](/visualization/message-path-syntax.md) on a customizable dial gauge display. It is useful for monitoring single numeric readings such as speed, temperature, battery level, or any other scalar measurement.

--- a/docs/visualization/panels/gauge-panel.md
+++ b/docs/visualization/panels/gauge-panel.md
@@ -2,6 +2,7 @@
 sidebar_position: 3
 title: "Gauge Panel"
 description: "Display numeric topic values on a customizable dial gauge for at-a-glance scalar monitoring."
+keywords: [gauge, dial, numeric, scalar, monitoring, metrics, topics]
 ---
 
 # Gauge Panel

--- a/docs/visualization/panels/image-panel.md
+++ b/docs/visualization/panels/image-panel.md
@@ -1,5 +1,6 @@
 ---
 id: image-panel
+sidebar_position: 4
 title: Image Panel
 description: Display raw and compressed images, as well as compressed videos.
 ---

--- a/docs/visualization/panels/image-panel.md
+++ b/docs/visualization/panels/image-panel.md
@@ -3,6 +3,7 @@ id: image-panel
 sidebar_position: 4
 title: Image Panel
 description: Display raw and compressed images, as well as compressed videos.
+keywords: [image, camera, raw image, compressed image, video, annotations, visualization]
 ---
 
 The Image Panel enables you to display raw and compressed image data, as well as compressed video streams, directly within the workspace. It supports intuitive 2D annotations—including text labels, circles, and key points—for contextual markup. Additionally, you can overlay 3D markers on top of the visual content to provide spatial insight and enhance data interpretation.

--- a/docs/visualization/panels/indicator-panel.md
+++ b/docs/visualization/panels/indicator-panel.md
@@ -2,6 +2,7 @@
 sidebar_position: 5
 title: "Indicator Panel"
 description: "Display a color-coded label to indicate threshold values and system state at a glance."
+keywords: [indicator, threshold, status, alert, color, state, monitoring]
 ---
 
 # Indicator Panel

--- a/docs/visualization/panels/indicator-panel.md
+++ b/docs/visualization/panels/indicator-panel.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 5
+title: "Indicator Panel"
+description: "Display a color-coded label to indicate threshold values and system state at a glance."
+---
+
 # Indicator Panel
 
 The Indicator Panel in Lichtblick displays a color-coded label to indicate threshold values in your data. It is useful for providing at-a-glance status information, such as whether a sensor reading is within acceptable limits or if a system state requires attention.

--- a/docs/visualization/panels/map-panel.md
+++ b/docs/visualization/panels/map-panel.md
@@ -1,7 +1,8 @@
 ---
 id: map-panel
+sidebar_position: 6
 title: Map Panel
-description: Display GPS and GeoJSON data on a world map. 
+description: Display GPS and GeoJSON data on a world map.
 ---
 
 Display GPS and GeoJSON data on a world map.

--- a/docs/visualization/panels/map-panel.md
+++ b/docs/visualization/panels/map-panel.md
@@ -3,6 +3,7 @@ id: map-panel
 sidebar_position: 6
 title: Map Panel
 description: Display GPS and GeoJSON data on a world map.
+keywords: [map, gps, geojson, location, navigation, world map, visualization]
 ---
 
 Display GPS and GeoJSON data on a world map.

--- a/docs/visualization/panels/panels-introduction.md
+++ b/docs/visualization/panels/panels-introduction.md
@@ -1,5 +1,8 @@
 ---
 slug: /visualization/panels
+sidebar_position: 1
+title: "Panels"
+description: "Overview of Lichtblick's modular panels for visualizing and interacting with robotics data."
 ---
 
 # Panels

--- a/docs/visualization/panels/panels-introduction.md
+++ b/docs/visualization/panels/panels-introduction.md
@@ -3,6 +3,7 @@ slug: /visualization/panels
 sidebar_position: 1
 title: "Panels"
 description: "Overview of Lichtblick's modular panels for visualizing and interacting with robotics data."
+keywords: [panels, visualization, layout, modular, robotics, overview]
 ---
 
 # Panels

--- a/docs/visualization/panels/playback-performance.md
+++ b/docs/visualization/panels/playback-performance.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 7
+title: "Playback Performance Panel"
+description: "Monitor real-time playback performance metrics including speed, frame rate, and bandwidth."
+---
+
 # Playback Performance Panel
 
 ## Overview

--- a/docs/visualization/panels/playback-performance.md
+++ b/docs/visualization/panels/playback-performance.md
@@ -2,6 +2,7 @@
 sidebar_position: 7
 title: "Playback Performance Panel"
 description: "Monitor real-time playback performance metrics including speed, frame rate, and bandwidth."
+keywords: [playback performance, fps, frame rate, bandwidth, metrics, monitoring, speed]
 ---
 
 # Playback Performance Panel

--- a/docs/visualization/panels/plot-panel.md
+++ b/docs/visualization/panels/plot-panel.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 8
+title: "Plot Panel"
+description: "Visualize and plot time-series data from message topics as interactive charts."
+---
+
 # Plot
 
 The Plot Panel in Lichtblick is a user interface component designed to facilitate the visualization and control of plotting data. It allows to view, modify, and export graphical representations of datasets or modeling results.

--- a/docs/visualization/panels/plot-panel.md
+++ b/docs/visualization/panels/plot-panel.md
@@ -2,6 +2,7 @@
 sidebar_position: 8
 title: "Plot Panel"
 description: "Visualize and plot time-series data from message topics as interactive charts."
+keywords: [plot, chart, time-series, graph, data visualization, topics, metrics]
 ---
 
 # Plot

--- a/docs/visualization/panels/raw-messages-panel.md
+++ b/docs/visualization/panels/raw-messages-panel.md
@@ -2,6 +2,7 @@
 sidebar_position: 9
 title: "Raw Messages Panel"
 description: "Inspect raw ROS or MCAP messages in a structured JSON view with diff and filtering support."
+keywords: [raw messages, json, inspection, debug, ros, mcap, topics, diff]
 ---
 
 # Raw Messages

--- a/docs/visualization/panels/raw-messages-panel.md
+++ b/docs/visualization/panels/raw-messages-panel.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 9
+title: "Raw Messages Panel"
+description: "Inspect raw ROS or MCAP messages in a structured JSON view with diff and filtering support."
+---
+
 # Raw Messages
 
 The **Raw Messages** panel in Lichtblick is a powerful debugging and inspection tool that enables users to visualize raw [ROS](/connecting-to-data/frameworks/ros1.md) or [MCAP](/connecting-to-data/frameworks/mcap.md) messages in a structured and interactive JSON format. It is particularly useful for understanding message structures, tracking state changes over time, and drilling into specific message fields for advanced diagnostics or visualizations.

--- a/docs/visualization/panels/teleop-panel.md
+++ b/docs/visualization/panels/teleop-panel.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 10
+title: "Teleoperation Panel"
+description: "Remotely control your robot by publishing Twist messages via the teleoperation interface."
+---
+
 # Teleoperation Panel
 
 The Teleoperation Panel allows you to remotely control your robot by sending [geometry\_msgs/Twist](https://docs.ros.org/en/api/geometry_msgs/html/msg/Twist.html) or [geometry\_msgs/msg/Twist](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/msg/Twist.msg) messages directly to your active ROS system.

--- a/docs/visualization/panels/teleop-panel.md
+++ b/docs/visualization/panels/teleop-panel.md
@@ -2,6 +2,7 @@
 sidebar_position: 10
 title: "Teleoperation Panel"
 description: "Remotely control your robot by publishing Twist messages via the teleoperation interface."
+keywords: [teleoperation, teleop, twist, robot control, ros, remote, geometry_msgs]
 ---
 
 # Teleoperation Panel

--- a/docs/visualization/panels/user-scripts.md
+++ b/docs/visualization/panels/user-scripts.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 11
+title: "User Scripts Panel"
+description: "Create synthetic topics in Lichtblick by processing and reshaping messages with TypeScript scripts."
+---
+
 # User Scripts Panel
 
 User Scripts enable you to create synthetic topics in Lichtblick by processing and reshaping existing messages. These scripts are especially useful for extracting insights, generating visualization-friendly data, or filtering out irrelevant noise from playback or full-range messages.

--- a/docs/visualization/panels/user-scripts.md
+++ b/docs/visualization/panels/user-scripts.md
@@ -2,6 +2,7 @@
 sidebar_position: 11
 title: "User Scripts Panel"
 description: "Create synthetic topics in Lichtblick by processing and reshaping messages with TypeScript scripts."
+keywords: [user scripts, typescript, synthetic topics, scripting, data processing, custom]
 ---
 
 # User Scripts Panel

--- a/docs/visualization/playback.md
+++ b/docs/visualization/playback.md
@@ -2,6 +2,7 @@
 sidebar_position: 2
 title: "Playback"
 description: "Navigate and control playback of local and remote datasets using Lichtblick's playback controls."
+keywords: [playback, controls, navigation, timeline, seek, speed, datasets]
 ---
 
 # Playback

--- a/docs/visualization/playback.md
+++ b/docs/visualization/playback.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 2
+title: "Playback"
+description: "Navigate and control playback of local and remote datasets using Lichtblick's playback controls."
+---
+
 # Playback
 
 Lichtblick enables seamless navigation through both local and remote datasets using its playback controls.

--- a/docs/visualization/shortcuts.md
+++ b/docs/visualization/shortcuts.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 6
+title: "Keyboard Shortcuts"
+description: "Keyboard shortcuts for navigating and controlling playback in the Lichtblick interface."
+---
+
 # Shortcuts
 
 Use keyboard shortcuts to efficiently navigate the Lichtblick visualization interface.

--- a/docs/visualization/shortcuts.md
+++ b/docs/visualization/shortcuts.md
@@ -2,6 +2,7 @@
 sidebar_position: 6
 title: "Keyboard Shortcuts"
 description: "Keyboard shortcuts for navigating and controlling playback in the Lichtblick interface."
+keywords: [keyboard shortcuts, hotkeys, navigation, playback, controls]
 ---
 
 # Shortcuts

--- a/docs/visualization/sync-instances.md
+++ b/docs/visualization/sync-instances.md
@@ -2,6 +2,7 @@
 sidebar_position: 8
 title: "Synchronizing Instances"
 description: "Synchronize playback across multiple Lichtblick instances on the same platform."
+keywords: [sync, synchronize, multiple instances, playback, coordination]
 ---
 
 # Synchronizing Instances

--- a/docs/visualization/sync-instances.md
+++ b/docs/visualization/sync-instances.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 8
+title: "Synchronizing Instances"
+description: "Synchronize playback across multiple Lichtblick instances on the same platform."
+---
+
 # Synchronizing Instances
 
 ## Overview

--- a/docs/visualization/variables.md
+++ b/docs/visualization/variables.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 4
+title: "Variables"
+description: "Define global variables to reuse values consistently across multiple panels in a layout."
+---
+
 # Variables
 
 Variables in Lichtblick allow users to define global values that can be reused across multiple panels within a layout. This feature simplifies updates and ensures consistency throughout your workspace. Variables can store primitive data types such as strings, numbers, or booleans. They can also be structured as arrays (e.g., `["x", 2, false]`) or maps (e.g., `{ "x": 2, "y": false }`).

--- a/docs/visualization/variables.md
+++ b/docs/visualization/variables.md
@@ -2,6 +2,7 @@
 sidebar_position: 4
 title: "Variables"
 description: "Define global variables to reuse values consistently across multiple panels in a layout."
+keywords: [variables, global state, layout, panels, parameters, reuse]
 ---
 
 # Variables

--- a/guides/create-custom-camera-model.md
+++ b/guides/create-custom-camera-model.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 5
+title: "Create Custom Camera Model"
+description: "Build a custom camera model extension to handle specialized camera configurations in Lichtblick."
 ---
 
 # Create Custom Camera Model

--- a/guides/create-custom-camera-model.md
+++ b/guides/create-custom-camera-model.md
@@ -2,6 +2,7 @@
 sidebar_position: 5
 title: "Create Custom Camera Model"
 description: "Build a custom camera model extension to handle specialized camera configurations in Lichtblick."
+keywords: [custom camera model, fisheye, distortion, extension, typescript, tutorial, guide]
 ---
 
 # Create Custom Camera Model

--- a/guides/create-custom-panel.md
+++ b/guides/create-custom-panel.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 2
+title: "Create Custom Panel"
+description: "Build a custom panel extension to visualize and interact with your robotics data in Lichtblick."
 ---
 
 # Create Custom Panel

--- a/guides/create-custom-panel.md
+++ b/guides/create-custom-panel.md
@@ -2,6 +2,7 @@
 sidebar_position: 2
 title: "Create Custom Panel"
 description: "Build a custom panel extension to visualize and interact with your robotics data in Lichtblick."
+keywords: [custom panel, extension, typescript, tutorial, guide, react, visualization]
 ---
 
 # Create Custom Panel

--- a/guides/create-custom-websocket-server.md
+++ b/guides/create-custom-websocket-server.md
@@ -2,6 +2,7 @@
 sidebar_position: 6
 title: "Create Custom WebSocket Server"
 description: "Build a WebSocket server using the Foxglove WebSocket Protocol to stream real-time data to Lichtblick."
+keywords: [websocket, custom server, foxglove protocol, live data, tutorial, guide, typescript]
 ---
 
 # Create Custom WebSocket Server

--- a/guides/create-custom-websocket-server.md
+++ b/guides/create-custom-websocket-server.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 6
+title: "Create Custom WebSocket Server"
+description: "Build a WebSocket server using the Foxglove WebSocket Protocol to stream real-time data to Lichtblick."
 ---
 
 # Create Custom WebSocket Server

--- a/guides/create-message-converter.md
+++ b/guides/create-message-converter.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 3
+title: "Create Message Converter"
+description: "Build a message converter extension to transform custom messages into Foxglove-supported schemas."
 ---
 
 # Create Message Converter

--- a/guides/create-message-converter.md
+++ b/guides/create-message-converter.md
@@ -2,6 +2,7 @@
 sidebar_position: 3
 title: "Create Message Converter"
 description: "Build a message converter extension to transform custom messages into Foxglove-supported schemas."
+keywords: [message converter, extension, typescript, tutorial, guide, schema, transform]
 ---
 
 # Create Message Converter

--- a/guides/create-topic-alias.md
+++ b/guides/create-topic-alias.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 4
+title: "Create Topic Alias"
+description: "Build a topic alias extension to create alternative names for topics in Lichtblick."
 ---
 
 # Create Topic Alias

--- a/guides/create-topic-alias.md
+++ b/guides/create-topic-alias.md
@@ -2,6 +2,7 @@
 sidebar_position: 4
 title: "Create Topic Alias"
 description: "Build a topic alias extension to create alternative names for topics in Lichtblick."
+keywords: [topic alias, extension, typescript, tutorial, guide, topics, remapping]
 ---
 
 # Create Topic Alias

--- a/guides/introduction.md
+++ b/guides/introduction.md
@@ -3,6 +3,7 @@ sidebar_position: 1
 title: Introduction
 slug: /
 description: "Step-by-step tutorials for extending Lichtblick and integrating it with your robotics workflows."
+keywords: [guide, tutorial, introduction, how to, extensions, robotics, workflows]
 ---
 
 # Introduction

--- a/guides/introduction.md
+++ b/guides/introduction.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: Introduction
 slug: /
+description: "Step-by-step tutorials for extending Lichtblick and integrating it with your robotics workflows."
 ---
 
 # Introduction


### PR DESCRIPTION
**Description:**
Ensures every documentation page has complete YAML frontmatter (`title`, `description`, `sidebar_position`) and adds a `keywords` array to all pages to improve Algolia search ranking and discoverability.